### PR TITLE
Pool Size Screen

### DIFF
--- a/app/src/main/java/edu/drexel/lapcounter/lapcounter/frontend/PoolSizeActivity.java
+++ b/app/src/main/java/edu/drexel/lapcounter/lapcounter/frontend/PoolSizeActivity.java
@@ -1,22 +1,198 @@
 package edu.drexel.lapcounter.lapcounter.frontend;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.Log;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.RadioButton;
 
 import edu.drexel.lapcounter.lapcounter.R;
 import edu.drexel.lapcounter.lapcounter.frontend.navigationbar.NavBar;
 
 public class PoolSizeActivity extends AppCompatActivity {
     private final NavBar mNavBar = new NavBar(this, R.id.navigation_settings);
+    private static final String TAG = DeviceSelectActivity.class.getSimpleName();
+    //Default Values
+    private static final int defPoolSize = 25;
+    private static final String defPoolUnits = "Yards";
+
+    //Keys used for loading/save pool size and units
+    private static final String poolSizePreferences = "pool_size_pref";
+    private static final String poolSizeKey = "pool_size_key";
+    private static final String poolUnitsKey = "pool_size_units";
+
+    private EditText custom_pool_text;
+    private int poolSize;
+    private String poolUnits;
+    private SharedPreferences pref;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_pool_size);
 
-        // In the final version, use R.string.<string id> for titles
-        getSupportActionBar().setTitle("Pool Size");
-
+        getSupportActionBar().setTitle(R.string.pool_size_title);
         mNavBar.init();
+
+        custom_pool_text = findViewById(R.id.pool_size_custom_text);
+        custom_pool_text.addTextChangedListener(new TextWatcher()
+        {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                tryGetCustomPoolSize(s.toString());
+            }
+        });
+
+        pref = getSharedPreferences(poolSizePreferences, Context.MODE_PRIVATE);
+        loadPoolData();
     }
+
+    //Load the saved pool data and setup our two radio groups
+    private void loadPoolData()
+    {
+        poolSize = pref.getInt(poolSizeKey,defPoolSize);
+        poolUnits = pref.getString(poolUnitsKey,defPoolUnits);
+        Log.i(TAG,String.format("poolSize:%d, poolUnits:%s",poolSize,poolUnits));
+
+        //Pool Size RadioGroup Setup
+        if(poolSize == 25)
+        {
+            ((RadioButton) findViewById(R.id.pool_size_25)).setChecked(true);
+        }
+        else if(poolSize == 50)
+        {
+            ((RadioButton) findViewById(R.id.pool_size_50)).setChecked(true);
+        }
+        else//Custom
+        {
+            ((RadioButton) findViewById(R.id.pool_size_custom)).setChecked(true);
+            custom_pool_text.setText(String.valueOf(poolSize));
+            custom_pool_text.setEnabled(true);
+        }
+
+        //Pool Size Units RadioGroup Setup
+        if(poolUnits.equals("Yards"))
+        {
+            ((RadioButton) findViewById(R.id.pool_units_yards)).setChecked(true);
+        }
+        else
+        {
+            ((RadioButton) findViewById(R.id.pool_units_meters)).setChecked(true);
+        }
+    }
+
+
+    @Override
+    protected void onDestroy()
+    {
+        super.onDestroy();
+        SharedPreferences.Editor editor = pref.edit();
+        editor.putInt(poolSizeKey,poolSize);
+        editor.putString(poolUnitsKey,poolUnits);
+        editor.apply();
+    }
+
+    @Override
+    protected  void onPause()
+    {
+        super.onPause();
+        SharedPreferences.Editor editor = pref.edit();
+        editor.putInt(poolSizeKey,poolSize);
+        editor.putString(poolUnitsKey,poolUnits);
+        editor.apply();
+    }
+
+    protected  void onResume()
+    {
+        super.onResume();
+        loadPoolData();
+    }
+
+    public void onPoolSizeRadioButtonClicked(View view)
+    {
+
+        boolean checked = ((RadioButton) view).isChecked();
+        switch(view.getId())
+        {
+            case R.id.pool_size_25:
+                if(checked)
+                {
+                    //Coming from Custom
+                    if(custom_pool_text.isEnabled())
+                    {
+                        custom_pool_text.setEnabled(false);
+                    }
+                    poolSize = 25;
+                    break;
+                }
+            case R.id.pool_size_50:
+                if(checked)
+                {
+                    //Coming from Custom
+                    if(custom_pool_text.isEnabled())
+                    {
+                        custom_pool_text.setEnabled(false);
+                    }
+                    poolSize = 50;
+                    break;
+                }
+            case R.id.pool_size_custom:
+                if(checked)
+                {
+                    custom_pool_text.setEnabled(true);
+                    tryGetCustomPoolSize(custom_pool_text.getText().toString());
+                    break;
+                }
+
+        }
+    }
+
+    public void onPoolUnitsRadioButtonClicked(View view)
+    {
+        boolean checked = ((RadioButton) view).isChecked();
+        switch(view.getId())
+        {
+            case R.id.pool_units_yards:
+                if(checked)
+                {
+                    poolUnits = "Yards";
+                    break;
+                }
+            case R.id.pool_units_meters:
+                if(checked)
+                {
+                    poolUnits = "Meters";
+                    break;
+                }
+        }
+    }
+
+    private void tryGetCustomPoolSize(String s)
+    {
+        int val = 0;
+        try
+        {
+            val = Integer.parseInt(s);
+        }
+        catch(Exception e)
+        {
+            Log.i("EXCEPTION",e.toString());
+            return;
+        }
+        poolSize = val;
+    }
+
+
 }

--- a/app/src/main/res/layout/activity_pool_size.xml
+++ b/app/src/main/res/layout/activity_pool_size.xml
@@ -7,27 +7,111 @@
     tools:context=".frontend.PoolSizeActivity">
 
 
+    <TextView
+        android:id="@+id/unitText"
+        android:layout_width="171dp"
+        android:layout_height="56dp"
+        android:layout_marginEnd="20dp"
+        android:ems="10"
+        android:text="@string/units"
+        android:textAlignment="center"
+        android:textSize="30sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/SizeText"
+        android:layout_width="171dp"
+        android:layout_height="56dp"
+        android:layout_marginStart="20dp"
+        android:ems="10"
+        android:text="@string/size"
+        android:textAlignment="center"
+        android:textSize="30sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+
     <RadioGroup
         android:id="@+id/pool_size_radio_group"
-        android:layout_width="96dp"
-        android:layout_height="64dp"
-        tools:layout_editor_absoluteX="128dp"
-        tools:layout_editor_absoluteY="69dp" >
+        android:layout_width="171dp"
+        android:layout_height="310dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="36dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <RadioButton
             android:id="@+id/pool_size_25"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="25"
-            android:checked="true"
-            android:onClick="onRadioButtonClicked"/>
+            android:layout_width="137dp"
+            android:layout_height="75dp"
+            android:onClick="onPoolSizeRadioButtonClicked"
+            android:text="@string/num_25"
+            android:textSize="30sp" />
 
         <RadioButton
             android:id="@+id/pool_size_50"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="50"
-            android:onClick="onRadioButtonClicked"/>
+            android:layout_width="137dp"
+            android:layout_height="75dp"
+            android:onClick="onPoolSizeRadioButtonClicked"
+            android:text="@string/num_50"
+            android:textSize="30sp" />
+
+        <RadioButton
+            android:id="@+id/pool_size_custom"
+            android:layout_width="137dp"
+            android:layout_height="75dp"
+            android:onClick="onPoolSizeRadioButtonClicked"
+            android:text="@string/custom"
+            android:textSize="29sp" />
+
+    </RadioGroup>
+
+    <EditText
+        android:id="@+id/pool_size_custom_text"
+        android:layout_width="42dp"
+        android:layout_height="61dp"
+        android:layout_marginStart="160dp"
+        android:layout_marginTop="196dp"
+        android:layout_marginEnd="8dp"
+        android:enabled="false"
+        android:inputType="number"
+        android:text="@string/num_35"
+        android:textAlignment="center"
+        android:textSize="30sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <RadioGroup
+        android:id="@+id/pool_units_radio_group"
+        android:layout_width="171dp"
+        android:layout_height="310dp"
+        android:layout_marginStart="40dp"
+        android:layout_marginTop="36dp"
+        android:layout_marginEnd="20dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toEndOf="@+id/pool_size_radio_group"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <RadioButton
+            android:id="@+id/pool_units_yards"
+            android:layout_width="137dp"
+            android:layout_height="75dp"
+            android:onClick="onPoolUnitsRadioButtonClicked"
+            android:text="@string/yards"
+            android:textSize="30sp" />
+
+        <RadioButton
+            android:id="@+id/pool_units_meters"
+            android:layout_width="137dp"
+            android:layout_height="75dp"
+            android:onClick="onPoolUnitsRadioButtonClicked"
+            android:text="@string/meters"
+            android:textSize="30sp" />
     </RadioGroup>
 
     <android.support.design.widget.BottomNavigationView
@@ -42,7 +126,5 @@
         app:layout_constraintRight_toRightOf="parent"
         app:menu="@menu/navigation"
         app:labelVisibilityMode="labeled" />
-
-
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,13 @@
     <string name="i_device_name">DEVICE_NAME</string>
     <string name="i_device_mac">DEVICE_MAC</string>
     <string name="i_device_rssi">DEVICE_RSSI</string>
+    <string name="pool_size_title">"Pool Size"</string>
+    <string name="meters">Meters</string>
+    <string name="yards">"Yards"</string>
+    <string name="num_25">"25"</string>
+    <string name="num_50">"50"</string>
+    <string name="num_35">"35"</string>
+    <string name="custom">"Custom"</string>
+    <string name="units">"Units</string>
+    <string name="size">"Size"</string>
 </resources>


### PR DESCRIPTION
Pull Request for the Pool Size screen.  User can select from either 25, 50, or custom amount of size.  They can also select either Meters or Yards for their units.  This data is saved to the device with SharePreferences on the activity being destroyed or paused.  Data is loaded onResume and onCreate.