### PR TITLE
Add TransitionLog to LCS test

### DIFF
--- a/app/src/main/java/edu/drexel/lapcounter/lapcounter/backend/lapcounter/LapCounterService.java
+++ b/app/src/main/java/edu/drexel/lapcounter/lapcounter/backend/lapcounter/LapCounterService.java
@@ -58,12 +58,17 @@ public class LapCounterService extends Service {
     public LapCounterService() {}
 
     // Constructor for mocking in unit tests.
-    public LapCounterService(LocationStateMachine lsm, DisconnectManager dm, LapCounter lc,
-                             SimpleMessageReceiver r) {
+    public LapCounterService(
+            LocationStateMachine lsm,
+            DisconnectManager dm,
+            LapCounter lc,
+            SimpleMessageReceiver r,
+            TransitionLog lg) {
         mStateMachine = lsm;
         mDisconnectManager = dm;
         mLapCounter = lc;
         mReceiver = r;
+        mLog = lg;
     }
 
     /**

--- a/app/src/test/java/edu/drexel/lapcounter/lapcounter/backend/lapcounter/LapCounterServiceTest.java
+++ b/app/src/test/java/edu/drexel/lapcounter/lapcounter/backend/lapcounter/LapCounterServiceTest.java
@@ -24,6 +24,7 @@ public class LapCounterServiceTest {
     private SimpleMessageReceiver mReceiver;
 
     private LapCounterService mService;
+    private TransitionLog mLog;
 
     @Before
     public void setup() {
@@ -32,8 +33,10 @@ public class LapCounterServiceTest {
         mLapCounter = mock(LapCounter.class);
 
         mReceiver = mock(SimpleMessageReceiver.class);
+        mLog = mock(TransitionLog.class);
 
-        mService = new LapCounterService(mStateMachine, mDisconnectManager, mLapCounter, mReceiver);
+        mService = new LapCounterService(
+                mStateMachine, mDisconnectManager, mLapCounter, mReceiver, mLog);
     }
 
     @Test


### PR DESCRIPTION
This fixes a NullPointerException in one of the test cases.